### PR TITLE
Update download assets and media section on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,12 +86,28 @@
       <h2>Resources & Media</h2>
       <div class="media-grid">
         <div class="media-item">
-          <img src="assets/media1.jpg" alt="Sample media"/>
-          <a href="downloads/share_kit.zip" download class="btn">Download</a>
+          <img src="assets/aphobia.png" alt="Apostophobia Logo"/>
+          <a href="assets/aphobia.png" download class="btn">Download</a>
         </div>
         <div class="media-item">
-          <img src="assets/aphobia.png" alt="Apostophobia Logo"/>
-          <a href="assets/aphobia.png" download class="btn">Download Logo</a>
+          <img src="assets/white-01@3x-8.png" alt="White Logo Variant 1"/>
+          <a href="assets/white-01@3x-8.png" download class="btn">Download</a>
+        </div>
+        <div class="media-item">
+          <img src="assets/white-02@3x-8.png" alt="White Logo Variant 2"/>
+          <a href="assets/white-02@3x-8.png" download class="btn">Download</a>
+        </div>
+        <div class="media-item">
+          <img src="assets/black-02@3x-8.png" alt="Black Logo Variant"/>
+          <a href="assets/black-02@3x-8.png" download class="btn">Download</a>
+        </div>
+        <div class="media-item">
+          <img src="assets/red-02@3x-8.png" alt="Red Logo Variant"/>
+          <a href="assets/red-02@3x-8.png" download class="btn">Download</a>
+        </div>
+        <div class="media-item">
+          <img src="assets/end_apostophobia.png" alt="End Apostophobia"/>
+          <a href="assets/end_apostophobia.png" download class="btn">Download</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Updated the Resources & Media section on the homepage
- Replaced existing media items with new logo and image assets
- Added multiple logo variants for download including white, black, and red versions
- Improved user experience by providing direct download links for each asset

## Changes

### Frontend
- Modified `index.html` to update the media grid
- Replaced old media images and download links with new assets:
  - Apostophobia Logo
  - White Logo Variant 1
  - White Logo Variant 2
  - Black Logo Variant
  - Red Logo Variant
  - End Apostophobia image
- Each media item now includes an image preview and a download button linking to the respective asset

## Test plan
- [x] Verify all new images display correctly in the media grid
- [x] Confirm download buttons trigger download of the correct asset files
- [x] Check layout and styling remain consistent after asset updates

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ebeed153-adc8-4abc-a53a-dcdc1c4b4c95