### PR TITLE
Add Google Analytics tracking to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,15 @@
   <meta name="apple-mobile-web-app-title" content="Apostophobia">
   
   <link rel="manifest" href="site.webmanifest">
+  
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'GA_MEASUREMENT_ID');
+  </script>
 </head>
 <body>
   <header id="site-header">


### PR DESCRIPTION
## Summary
- Integrates Google Analytics into the website for tracking and analytics purposes
- Adds the necessary Google Analytics script and initialization code to the `index.html` file

## Changes

### Frontend
- Inserted Google Analytics script tag asynchronously loading the `gtag.js` library
- Added inline script to initialize Google Analytics with `GA_MEASUREMENT_ID` placeholder

## Test plan
- [ ] Verify that the Google Analytics script loads correctly on the homepage
- [ ] Confirm that page views and events are tracked in the Google Analytics dashboard after replacing `GA_MEASUREMENT_ID` with a valid ID
- [ ] Check that no errors occur in the browser console related to Google Analytics script

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e6d15141-6dc3-4b75-a347-5eb22551a811