### PR TITLE
Change freebetty campaign header text color to black

### DIFF
--- a/style.css
+++ b/style.css
@@ -208,7 +208,7 @@ section h2 {
 }
 
 .freebetty-campaign h3 {
-  color: #dc1414 !important;
+  color: black !important;
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary
- Updates the text color of the `.freebetty-campaign h3` header from red (#dc1414) to black

## Changes

### CSS Styling
- Modified `style.css`:
  - Changed `.freebetty-campaign h3` color property from `#dc1414 !important` to `black !important` to improve visual consistency or meet design requirements

## Test plan
- [x] Verify that the `.freebetty-campaign h3` text appears black on the campaign page
- [x] Confirm no other styles are affected by this change
- [x] Check for visual consistency across different browsers and devices

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/aa90f455-4134-4859-83fc-a4f462107cf2