### PR TITLE
style(ui): change FreeBetty campaign heading to black for better contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -208,7 +208,7 @@ section h2 {
 }
 
 .freebetty-campaign h3 {
-  color: #dc1414 !important;
+  color: black !important;
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary
- Changed the FreeBetty campaign heading text color from red (#dc1414) to black for better readability against the red background

## Test plan
- [x] Verify text is now black instead of red
- [x] Confirm text is readable against red background
- [ ] Test on different screen sizes and devices

🤖 Generated with [Claude Code](https://claude.ai/code)