### PR TITLE
Remove Apostasy Day announcement container from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,11 +72,6 @@
             </div>
           </div>
         </div>
-        <div class="announcement-box apostasy-day">
-          <h3>🎉 Join ExMuslims International on Apostasy Day</h3>
-          <p>End apostophobia and celebrate apostasy on <strong>August 22nd</strong> with EXMI. Stand up for the universal right to choose your own beliefs.</p>
-          <a href="https://ex-muslims.international/apostasy-day-2025-end-apostophobia-celebrate-apostasy/" target="_blank" class="btn">Learn More</a>
-        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Removes the Apostasy Day announcement box from the homepage
- Cleans up the `index.html` by deleting the related container and content

## Changes

### Frontend
- Deleted the `<div>` with class `announcement-box apostasy-day` from `index.html`
- Removed the heading, description, and link related to ExMuslims International Apostasy Day event

## Test plan
- Verify the homepage no longer displays the Apostasy Day announcement
- Ensure no layout or styling issues occur due to the removal
- Confirm the rest of the page content remains unaffected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/da7987f2-2d97-4931-940c-be05982f66ef